### PR TITLE
fix: copy local tools to global scope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ runs:
   steps:
     - name: Install asdf-vm
       uses: asdf-vm/actions/setup@v1.1.0
+      
+    # Some tools fork processes in different odd working directories. Adding dependencies to global helps.
+    - run: cp -f .tool-versions ~/.tool-versions 
 
     - name: Cache asdf tooling
       uses: actions/cache@v3

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ runs:
     - name: Install asdf-vm
       uses: asdf-vm/actions/setup@v1.1.0
       
-    # Some tools fork processes in different odd working directories. Adding dependencies to global helps.
+    # Some tools fork processes in odd working directories. Adding dependencies to global helps.
     - run: cp -f .tool-versions ~/.tool-versions 
 
     - name: Cache asdf tooling


### PR DESCRIPTION
CodeQL for instance does weird stuff while forking its processes. Adding local tools to the global scope seems to help.
